### PR TITLE
[nix] update vendor hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
           pname = "replit-ebpf";
           version = "0.0.01";
           src = ./.;
-          vendorHash = "sha256-4xB98fvnU/fi6FHDjIbVW/yGZobaNhI1jvTGY1IiT9k=";
+          vendorHash = "sha256-M6fUOce+IoHwrbFdoT6HybsTroKexblbG6M//ZdFrQw=";
           buildInputs = [ pkgs.makeWrapper ];
 
           # integration tests require a local corrupted disk


### PR DESCRIPTION
Forgot to update in #9, this fixes `nix build` 